### PR TITLE
delete json requirement

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,6 +18,5 @@ class ApiTest < Minitest::Test
   def load_data(path)
     r = connection.get(path)
     assert_equal 200, r.status, "Expected Status Code 200, got #{r.status}"
-    assert_valid_json(r.body)
   end
 end


### PR DESCRIPTION
spec is inconsistent - it demands JSON data but then asserts that the data = "some string" (for example). both of these assertions cannot possibly pass, as the string you assert the data must equal is not valid JSON