### PR TITLE
change asserted favorite merchant for customer 66

### DIFF
--- a/test/business_logic/customer_business_logic_test.rb
+++ b/test/business_logic/customer_business_logic_test.rb
@@ -6,8 +6,8 @@ class CustomerApiBusinessLogicTest < ApiTest
     fav_merch_one   = load_data("/api/v1/customers/#{customer_id_one}/favorite_merchant")
     fav_merch_two   = load_data("/api/v1/customers/#{customer_id_two}/favorite_merchant")
 
-    assert_equal 94,          fav_merch_one["id"]
-    assert_equal "Boehm LLC", fav_merch_one["name"]
+    assert_equal 49,                         fav_merch_one["id"]
+    assert_equal "Marvin, Renner and Bauch", fav_merch_one["name"]
 
     assert_equal 69,                 fav_merch_two["id"]
     assert_equal "Watsica-Parisian", fav_merch_two["name"]


### PR DESCRIPTION
I think this might have been a case of transposing 49 to 94 somewhere along the way. I went into rails console and found customer 66. They have 9 successful invoices and 2 of those are for merchant 49. Merchant 49 is the only merchant where they have multiple successful invoices so it must be returned as the favorite. Should be able to replicate this in your console if you want to confirm on your end.