### PR TITLE
Add JSON parse quirks_mode

### DIFF
--- a/test/custom_assertions.rb
+++ b/test/custom_assertions.rb
@@ -1,7 +1,7 @@
 module CustomAssertions
   def assert_valid_json(data)
-    parsed = JSON.parse(data)
-    assert [Array, Hash].include?(parsed.class)
+    parsed = JSON.parse(data, :quirks_mode => true)
+    assert [Array, Hash, String].include?(parsed.class)
     parsed
   rescue JSON::ParserError
     flunk("Expected #{data} to be valid JSON.")


### PR DESCRIPTION
    The results of some of our queries were strings of a single value rather
    than a typical JSON Array or Hash. We could fix it by having everyone
    wrap their result in an Array and then expecting it in the test. We
    could also require everyone to put the value in a hash but then the key
    would have to be the same for everyone. Both are possible options. This
    fix gets around the problem by using the quirks_mode of JSON.parse which
    allows a string to pass through as valid. I'm proposing it here because it will
    fix the issues people are having without requiring everyone to change their
    code. Perhaps in the future one of the other solutions could be worked into
    the project specifications.