### PR TITLE
Change expected amount for merchant total by date

### DIFF
--- a/test/business_logic/merchant_business_logic_test.rb
+++ b/test/business_logic/merchant_business_logic_test.rb
@@ -50,7 +50,7 @@ class SingleMerchantApiBusinessLogicTest < ApiTest
     revenue_two = load_data("/api/v1/merchants/#{merchant_id_two}/revenue?date=#{date_two}")
 
     assert_equal "47424.45",   revenue_one
-    assert_equal "8116.35",    revenue_two
+    assert_equal "4671.73",    revenue_two
   end
 end
 


### PR DESCRIPTION
The total 8116.35 is the revenue total for 'merchant_id_two=3' for the date 'date_one'. This could have been a simple mistake when gathering the data for assertions. The total 4671.73 matches the total for 'merchant_id_two=3' on the date 'date_two'. You should be able to replicate this on your end to confirm.