### PR TITLE
Edit to custom_assertions.rb

### DIFF
--- a/test/custom_assertions.rb
+++ b/test/custom_assertions.rb
@@ -19,7 +19,7 @@ module CustomAssertions
   end
 
   def assert_response_has_attribute(attribute, entities)
-    result = entities.any? { |entity| entity.has_value?(attribute) }
+    result = entities.any? { |entity| entity["attributes"].has_value?(attribute) }
 
     assert result, "#{attribute} not found in collection"
   end


### PR DESCRIPTION
["attributes"] is needed to dig into the correct layer of the hash when called from test_loads_a_variable_number_of_top_merchants_ranked_by_total_revenue