### PR TITLE
Clean up remaining assertions

### DIFF
--- a/test/endpoints/invoice_items_test.rb
+++ b/test/endpoints/invoice_items_test.rb
@@ -144,7 +144,7 @@ class InvoiceItemsApiTest < ApiTest
     assert_equal 6, invoice_items.count
 
     expected_attributes.each do |attribute|
-      assert_equal invoice_find_all[attribute], invoice_items[1]["attributes"][attribute]
+      assert_equal invoice_find_all[attribute], invoice_items[4]["attributes"][attribute]
     end
   end
 

--- a/test/endpoints/invoice_items_test.rb
+++ b/test/endpoints/invoice_items_test.rb
@@ -168,7 +168,7 @@ class InvoiceItemsApiTest < ApiTest
     end
   end
 
-  def test_it_can_find_all_instances_by_time_values
+  def test_it_can_find_all_instances_by_created_time_values
     invoice_items = load_data("/api/v1/invoice_items/find_all?created_at=#{invoice_find_all['created_at']}")["data"]
 
     assert_equal 86, invoice_items.count
@@ -178,7 +178,7 @@ class InvoiceItemsApiTest < ApiTest
     end
   end
 
-  def test_it_can_find_all_instances_by_time_values
+  def test_it_can_find_all_instances_by_updated_time_values
     invoice_items = load_data("/api/v1/invoice_items/find_all?updated_at=#{invoice_find_all['updated_at']}")["data"]
 
     assert_equal 86, invoice_items.count

--- a/test/endpoints/invoice_items_test.rb
+++ b/test/endpoints/invoice_items_test.rb
@@ -174,7 +174,7 @@ class InvoiceItemsApiTest < ApiTest
     assert_equal 86, invoice_items.count
 
     expected_attributes.each do |attribute|
-      assert_equal invoice_find_all[attribute], invoice_items.first["attributes"][attribute]
+      assert_equal invoice_find_all[attribute], invoice_items[35]["attributes"][attribute]
     end
   end
 

--- a/test/endpoints/invoices_test.rb
+++ b/test/endpoints/invoices_test.rb
@@ -122,7 +122,7 @@ class InvoicesApiTest < ApiTest
     assert_equal 4, invoices.count
 
     expected_attributes.each do |attribute|
-      assert_equal invoice_find_all[attribute], invoices[2]["attributes"][attribute]
+      assert_equal invoice_find_all[attribute], invoices[1]["attributes"][attribute]
     end
   end
 

--- a/test/endpoints/transactions_test.rb
+++ b/test/endpoints/transactions_test.rb
@@ -121,7 +121,7 @@ class TransactionsApiTest < ApiTest
     assert_equal 2, transactions.count
 
     expected_attributes.each do |attribute|
-      assert_equal transaction_find_all[attribute], transactions.last["attributes"][attribute]
+      assert_equal transaction_find_all[attribute], transactions.first["attributes"][attribute]
     end
   end
 


### PR DESCRIPTION
In four places, changed which member out of the returned collection was selected for comparison against the expected result. Aligns with the guideline that returned collections should have members ordered by their ID, ascending.

Also fixed an instance of two tests with the same name, which was causing the first one to be skipped implicitly.